### PR TITLE
feat/opt: chunked decryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 safetensors/target
 safetensors/**/Cargo.lock
 bindings/python/Cargo.lock
+*__pycache__*
 *.bin
 *.h5
 *.msgpack

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -1,0 +1,108 @@
+# CryptoTensors File Format Specification
+
+CryptoTensors extends the [safetensors](https://github.com/huggingface/safetensors) format by introducing an encryption layer, a signature for integrity, and an access control policy. This document describes the layout of a CryptoTensors file and the metadata structure for both the legacy **v1** mapping and the newer **v2** chunked encryption.
+
+## File Layout
+
+The overall binary layout is identical to `safetensors`:
+
+1.  **Header Size (`N`)**: 8 bytes, an unsigned little-endian 64-bit integer, containing the size of the header.
+2.  **Header (JSON)**: `N` bytes, a UTF-8 JSON string.
+3.  **Tensor Data**: The remaining bytes in the file containing the actual tensor buffers.
+
+## Header Structure
+
+The header contains standard Safetensors fields (the tensor shapes, dtypes, and data offsets) along with a special `__metadata__` field. CryptoTensors injects its specific configurations into `__metadata__`:
+
+```json
+{
+    "tensor1": {
+        "dtype": "F16",
+        "shape": [1024, 1024],
+        "data_offsets": [0, 2097152]
+    },
+    "__metadata__": {
+        "__crypto_keys__": "...",
+        "__encryption__": "...",
+        "__signature__": "...",
+        "__policy__": "..."
+    }
+}
+```
+
+## `__crypto_keys__`
+
+This field defines the master keys' identities, algorithms, and the format version.
+
+### v1 (Monolithic Encryption)
+```json
+{
+    "version": "1",
+    "enc": {
+        "kid": "my-enc-key",
+        "alg": "aes256gcm",
+        "k": "...",
+        "kty": "oct"
+    },
+    "sign": {
+        "kid": "my-sign-key",
+        "alg": "ed25519",
+        "x": "...",
+        "kty": "okp"
+    }
+}
+```
+
+### v2 (Chunked Encryption)
+Introduced to allow parallelized decryption of large tensors.
+```json
+{
+    "version": "2",
+    "chunk_size": 2097152,  // Default 2MB. Determines how tensors are segmented.
+    "enc": { ... },
+    "sign": { ... }
+}
+```
+
+## `__encryption__`
+
+This field maps each tensor name to its specific encryption parameters. 
+
+### v1 (Monolithic Encryption)
+In v1, each tensor is encrypted as a single monolithic block.
+```json
+{
+    "tensor1": {
+        "enc_algo": "aes256gcm",
+        "wrapped_key": "<base64 encoded wrapped DEK>",
+        "key_iv": "<base64 encoded IV for key wrapper>",
+        "key_tag": "<base64 encoded Tag for key wrapper>",
+        "iv": "<base64 encoded IV for data>",
+        "tag": "<base64 encoded Tag for data>"
+    }
+}
+```
+
+### v2 (Chunked Encryption)
+In v2, large tensors are logically divided into chunks of `chunk_size` bytes (the last chunk may be smaller). Each chunk is encrypted independently.
+```json
+{
+    "tensor1": {
+        "enc_algo": "aes256gcm",
+        "wrapped_key": "<base64 encoded wrapped DEK>",
+        "key_iv": "<base64 encoded IV for key wrapper>",
+        "key_tag": "<base64 encoded Tag for key wrapper>",
+        "base_iv": "<base64 encoded Base IV (12 bytes)>",
+        "tags": "<base64 encoded concatenated tags for all chunks>"
+    }
+}
+```
+
+- **`base_iv`**: Used to deterministically derive per-chunk IVs. `chunk_iv[i] = base_iv[0..8] || (u32_from_be(base_iv[8..12]) + i).to_be_bytes()`.
+- **`tags`**: A concatenated binary blob of all authentication tags, appended sequentially for chunk 0, 1, 2, etc., and then base64-encoded. Length equals `num_chunks * tag_length` (where `tag_length` is 16 bytes for AES-GCM or ChaCha20-Poly1305).
+
+## `__signature__`
+A base64 encoded Ed25519 signature over the entire `__metadata__` JSON, excluding the `__signature__` field itself to prevent recursive dependencies.
+
+## `__policy__`
+A JSON-serialized struct containing local and remote [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) access control policies.

--- a/FORMAT.md
+++ b/FORMAT.md
@@ -102,7 +102,7 @@ In v2, large tensors are logically divided into chunks of `chunk_size` bytes (th
 - **`tags`**: A concatenated binary blob of all authentication tags, appended sequentially for chunk 0, 1, 2, etc., and then base64-encoded. Length equals `num_chunks * tag_length` (where `tag_length` is 16 bytes for AES-GCM or ChaCha20-Poly1305).
 
 ## `__signature__`
-A base64 encoded Ed25519 signature over the entire `__metadata__` JSON, excluding the `__signature__` field itself to prevent recursive dependencies.
+A base64 encoded Ed25519 signature over the entire header JSON object (all tensor entries plus the `__metadata__` field), with the `__signature__` field itself excluded from the signed data to prevent recursive dependencies.
 
 ## `__policy__`
 A JSON-serialized struct containing local and remote [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) access control policies.

--- a/README.md
+++ b/README.md
@@ -146,10 +146,13 @@ The file format is the same as the safetensors format, with the following additi
       with `BEGIN` as the starting offset and `END` as the one-past offset (so total tensor byte size = `END - BEGIN`).
   - A special key `__metadata__` is allowed to contain free form string-to-string map. Arbitrary JSON is not allowed, all values must be strings.
   - **Cryptotensors add the following fields to the `__metadata__` section**:
-    - `__encryption__`: JSON string containing per-tensor encryption information (algorithm, nonce, encrytped data encryption key, etc.)
-    - `__crypto_keys__`: JSON string containing key material information in the format `{"version": "1", "enc": {...}, "sign": {...}}`, where `enc` and `sign` are the metadata of the master decryption key and signing key respectively. No secrets are stored in this field, and the metadata is used to retrieve the keys from the key providers.
+    - `__encryption__`: JSON string containing per-tensor encryption information (algorithm, IVs, tags, wrapped keys, etc.). The format of this field depends on the `version` specified in `__crypto_keys__`.
+    - `__crypto_keys__`: JSON string containing key material information in the format `{"version": "1"|"2", "chunk_size": 2097152, "enc": {...}, "sign": {...}}`. `version` "1" uses monolithic encryption, while "2" uses chunked encryption. `chunk_size` is only present in version "2". No secrets are stored in this field, and the metadata is used to retrieve the keys from the key providers.
     - `__signature__`: Base64-encoded Ed25519 signature of the file header (excluding the signature itself) for integrity verification
     - `__policy__`: JSON string containing access control policy in Rego format
+  
+  For detailed format specifications and the differences between v1 and v2, please refer to [FORMAT.md](FORMAT.md).
+
 - Rest of the file: byte-buffer.
 
 ### Notes & Benefits

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -223,7 +223,7 @@ dependencies = [
 
 [[package]]
 name = "cryptotensors"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "base64",
  "hashbrown",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "cryptotensors-python"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "cryptotensors",
  "memmap2",

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -3,7 +3,7 @@
 
 [package]
 name = "cryptotensors-python"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.80"
 

--- a/bindings/python/benches/conftest.py
+++ b/bindings/python/benches/conftest.py
@@ -7,8 +7,8 @@ parent_dir = Path(__file__).parent.parent
 if str(parent_dir) not in sys.path:
     sys.path.insert(0, str(parent_dir))
 
-import pytest
-from tests.crypto_utils import generate_test_keys, create_crypto_config
+import pytest  # noqa: E402
+from tests.crypto_utils import generate_test_keys, create_crypto_config  # noqa: E402
 
 
 @pytest.fixture
@@ -18,7 +18,6 @@ def crypto_config():
     Supports BENCH_CRYPTO_ALGO environment variable to choose algorithm.
     """
     # Import locally to avoid issues with test structure in some environments
-    from tests.crypto_utils import generate_test_keys, create_crypto_config
 
     algo = os.environ.get("BENCH_CRYPTO_ALGO", "aes256gcm")
     keys = generate_test_keys(algorithm=algo)

--- a/bindings/python/benches/test_flax_crypto.py
+++ b/bindings/python/benches/test_flax_crypto.py
@@ -1,7 +1,5 @@
 import os
 import tempfile
-import pytest
-import numpy as np
 import jax.numpy as jnp
 from cryptotensors.flax import load_file, save_file
 

--- a/bindings/python/benches/test_mlx_crypto.py
+++ b/bindings/python/benches/test_mlx_crypto.py
@@ -2,7 +2,6 @@ import os
 import platform
 import tempfile
 import pytest
-import numpy as np
 
 HAS_MLX = False
 if platform.system() == "Darwin":

--- a/bindings/python/benches/test_numpy_crypto.py
+++ b/bindings/python/benches/test_numpy_crypto.py
@@ -1,6 +1,5 @@
 import os
 import tempfile
-import pytest
 import numpy as np
 from cryptotensors.numpy import load_file, save_file
 

--- a/bindings/python/benches/test_paddle_crypto.py
+++ b/bindings/python/benches/test_paddle_crypto.py
@@ -1,7 +1,5 @@
 import os
 import tempfile
-import pytest
-import numpy as np
 import paddle
 from cryptotensors.paddle import load_file, save_file
 

--- a/bindings/python/benches/test_tf_crypto.py
+++ b/bindings/python/benches/test_tf_crypto.py
@@ -1,7 +1,5 @@
 import os
 import tempfile
-import pytest
-import numpy as np
 import tensorflow as tf
 from cryptotensors.tensorflow import load_file, save_file
 

--- a/bindings/python/py_src/cryptotensors/__init__.py
+++ b/bindings/python/py_src/cryptotensors/__init__.py
@@ -127,6 +127,8 @@ class SerializeCryptoConfig:
         sign_jku=None,
         policy=None,
         tensors=None,
+        chunk_size=None,
+        version=None,
     ):
         """
         Initialize SerializeCryptoConfig
@@ -140,6 +142,8 @@ class SerializeCryptoConfig:
             sign_jku (str, optional): Signing key JWK URL
             policy (dict, optional): Access policy {"local": "...", "remote": "..."}
             tensors (list, optional): List of tensor names to encrypt (None = all)
+            chunk_size (int, optional): Size in bytes for chunked encryption. If None, uses default 2MB.
+            version (str, optional): CryptoTensors format version ("1" or "2"). If None, uses default V2.
         """
         self.config = {
             "enc_key": enc_key,
@@ -150,6 +154,8 @@ class SerializeCryptoConfig:
             "sign_jku": sign_jku,
             "policy": policy,
             "tensors": tensors,
+            "chunk_size": chunk_size,
+            "version": version,
         }
         # Remove None values
         self.config = {k: v for k, v in self.config.items() if v is not None}

--- a/bindings/python/py_src/cryptotensors/__init__.py
+++ b/bindings/python/py_src/cryptotensors/__init__.py
@@ -1,7 +1,6 @@
 # MODIFIED: Added encryption/decryption support for CryptoTensors
 # This is a derivative work based on the safetensors project by Hugging Face Inc.
 import json
-import os
 from importlib.metadata import entry_points
 from ._safetensors_rust import (  # noqa: F401
     SafetensorError,

--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -637,6 +637,16 @@ fn prepare_crypto(config: Option<PyBound<PyAny>>) -> PyResult<Option<SerializeCr
         ser_config.tensor_filter = Some(tensors_any.extract::<Vec<String>>()?);
     }
 
+    // Chunk size
+    if let Some(chunk_size) = config_dict.get_item("chunk_size")? {
+        ser_config.chunk_size = Some(chunk_size.extract::<usize>()?);
+    }
+
+    // Version
+    if let Some(version) = config_dict.get_item("version")? {
+        ser_config.version = Some(version.extract::<String>()?);
+    }
+
     Ok(Some(ser_config))
 }
 

--- a/bindings/python/tests/crypto_utils.py
+++ b/bindings/python/tests/crypto_utils.py
@@ -76,7 +76,7 @@ def generate_test_keys(algorithm="aes256gcm"):
     return {"enc_key": enc_key, "sign_key": sign_key}
 
 
-def create_crypto_config(enc_key, sign_key, tensors=None, policy=None):
+def create_crypto_config(enc_key, sign_key, tensors=None, policy=None, **kwargs):
     """
     Build encryption configuration dictionary for serialize/serialize_file.
 
@@ -85,6 +85,7 @@ def create_crypto_config(enc_key, sign_key, tensors=None, policy=None):
         sign_key (dict): Signing key material.
         tensors (list, optional): List of tensor names to encrypt. If None, all are encrypted.
         policy (dict, optional): Access policy dictionary.
+        **kwargs: Additional configuration parameters (e.g., chunk_size, version).
 
     Returns:
         dict: Configuration dictionary compatible with CryptoTensors API.
@@ -97,4 +98,5 @@ def create_crypto_config(enc_key, sign_key, tensors=None, policy=None):
         config["tensors"] = tensors
     if policy is not None:
         config["policy"] = policy
+    config.update(kwargs)
     return config

--- a/bindings/python/tests/test_crypto_config.py
+++ b/bindings/python/tests/test_crypto_config.py
@@ -9,6 +9,7 @@ def test_serialize_crypto_config():
         sign_kid="my-sign",
         policy={"local": "package model\nallow = true"},
         tensors=["weight", "bias"],
+        chunk_size=1048576,
     )
 
     config_dict = config.to_dict()
@@ -16,6 +17,7 @@ def test_serialize_crypto_config():
     assert config_dict["sign_kid"] == "my-sign"
     assert "policy" in config_dict
     assert config_dict["tensors"] == ["weight", "bias"]
+    assert config_dict["chunk_size"] == 1048576
 
 
 def test_serialize_crypto_config_minimal():

--- a/bindings/python/tests/test_crypto_config_integration.py
+++ b/bindings/python/tests/test_crypto_config_integration.py
@@ -11,7 +11,7 @@ import os
 torch = pytest.importorskip("torch")
 numpy = pytest.importorskip("numpy")
 
-from cryptotensors import (
+from cryptotensors import (  # noqa: E402
     SerializeCryptoConfig,
     DeserializeCryptoConfig,
     register_direct_key_provider,
@@ -19,8 +19,8 @@ from cryptotensors import (
     safe_open,
     rewrap_file,
 )
-from cryptotensors.torch import save_file
-from crypto_utils import generate_test_keys
+from cryptotensors.torch import save_file  # noqa: E402
+from crypto_utils import generate_test_keys  # noqa: E402
 
 
 class TestConfigIntegration:

--- a/bindings/python/tests/test_crypto_mlx.py
+++ b/bindings/python/tests/test_crypto_mlx.py
@@ -2,7 +2,6 @@ import os
 import platform
 import tempfile
 import unittest
-import numpy as np
 
 HAS_MLX = False
 if platform.system() == "Darwin":

--- a/bindings/python/tests/test_crypto_pt.py
+++ b/bindings/python/tests/test_crypto_pt.py
@@ -40,6 +40,33 @@ class CryptoPtTestCase(unittest.TestCase):
                 os.unlink(filename)
             except (OSError, PermissionError):
                 pass
+                
+    def test_roundtrip_encrypted_v1(self):
+        # Explicitly configure using version 1
+        config_v1 = create_crypto_config(**self.keys, version="1")
+        with tempfile.NamedTemporaryFile(suffix=".safetensors", delete=False) as f:
+            filename = f.name
+        try:
+            save_file(self.data, filename, config=config_v1)
+            
+            # Verify using safe_open that this is definitely a V1 file
+            with safe_open(filename, framework="pt") as handle:
+                reserved_metadata = handle.reserved_metadata()
+                import json
+                keys_meta = json.loads(reserved_metadata.get("__crypto_keys__", "{}"))
+                self.assertEqual(keys_meta.get("version"), "1")
+                self.assertNotIn("chunk_size", keys_meta)
+                
+            reloaded = load_file(filename)
+
+            for k, v in self.data.items():
+                tv = reloaded[k]
+                self.assertTrue(torch.allclose(v, tv))
+        finally:
+            try:
+                os.unlink(filename)
+            except (OSError, PermissionError):
+                pass
 
     def test_roundtrip_algorithms(self):
         algos = ["aes128gcm", "aes256gcm", "chacha20poly1305"]

--- a/bindings/python/tests/test_crypto_pt.py
+++ b/bindings/python/tests/test_crypto_pt.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 import unittest
 import torch
-import numpy as np
 import cryptotensors
 from cryptotensors.torch import load_file, save_file, safe_open
 from crypto_utils import generate_test_keys, create_crypto_config

--- a/bindings/python/tests/test_crypto_pt.py
+++ b/bindings/python/tests/test_crypto_pt.py
@@ -39,7 +39,7 @@ class CryptoPtTestCase(unittest.TestCase):
                 os.unlink(filename)
             except (OSError, PermissionError):
                 pass
-                
+
     def test_roundtrip_encrypted_v1(self):
         # Explicitly configure using version 1
         config_v1 = create_crypto_config(**self.keys, version="1")
@@ -47,15 +47,16 @@ class CryptoPtTestCase(unittest.TestCase):
             filename = f.name
         try:
             save_file(self.data, filename, config=config_v1)
-            
+
             # Verify using safe_open that this is definitely a V1 file
             with safe_open(filename, framework="pt") as handle:
                 reserved_metadata = handle.reserved_metadata()
                 import json
+
                 keys_meta = json.loads(reserved_metadata.get("__crypto_keys__", "{}"))
                 self.assertEqual(keys_meta.get("version"), "1")
                 self.assertNotIn("chunk_size", keys_meta)
-                
+
             reloaded = load_file(filename)
 
             for k, v in self.data.items():

--- a/safetensors/Cargo.toml
+++ b/safetensors/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cryptotensors"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 rust-version = "1.80"
 homepage = "https://github.com/aiyah-meloken/cryptotensors"

--- a/safetensors/src/cryptotensors.rs
+++ b/safetensors/src/cryptotensors.rs
@@ -1234,11 +1234,20 @@ impl CryptoTensors {
             .version
             .clone()
             .unwrap_or_else(|| CRYPTOTENSORS_VERSION_V2.to_string());
+        if version != CRYPTOTENSORS_VERSION_V1 && version != CRYPTOTENSORS_VERSION_V2 {
+            return Err(CryptoTensorsError::UnsupportedVersion(version.clone()));
+        }
 
         let chunk_size = if version == CRYPTOTENSORS_VERSION_V1 {
             None
         } else {
-            Some(config.chunk_size.unwrap_or(DEFAULT_CHUNK_SIZE))
+            let size = config.chunk_size.unwrap_or(DEFAULT_CHUNK_SIZE);
+            if size == 0 {
+                return Err(CryptoTensorsError::InvalidKey(
+                    "chunk_size must be greater than 0".to_string(),
+                ));
+            }
+            Some(size)
         };
 
         Ok(Some(Self {
@@ -1494,10 +1503,28 @@ impl CryptoTensors {
         if version != CRYPTOTENSORS_VERSION_V1 && version != CRYPTOTENSORS_VERSION_V2 {
             return Err(CryptoTensorsError::UnsupportedVersion(version.to_string()));
         }
-        let chunk_size = key_materials
-            .get("chunk_size")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize);
+        let chunk_size = match key_materials.get("chunk_size") {
+            Some(v) => {
+                let raw = v.as_u64().ok_or_else(|| {
+                    CryptoTensorsError::InvalidKey(
+                        "Invalid chunk_size in __crypto_keys__ header".to_string(),
+                    )
+                })?;
+                if raw == 0 {
+                    return Err(CryptoTensorsError::InvalidKey(
+                        "chunk_size must be greater than 0 in __crypto_keys__ header".to_string(),
+                    ));
+                }
+                Some(raw as usize)
+            }
+            None => {
+                if version == CRYPTOTENSORS_VERSION_V2 {
+                    Some(DEFAULT_CHUNK_SIZE)
+                } else {
+                    None
+                }
+            }
+        };
         let mut enc_key = KeyMaterial::from_header(&key_materials["enc"])?;
         let mut sign_key = KeyMaterial::from_header(&key_materials["sign"])?;
 

--- a/safetensors/src/cryptotensors.rs
+++ b/safetensors/src/cryptotensors.rs
@@ -26,14 +26,17 @@ use zeroize::Zeroizing;
 // ============================================================================
 // Version Constants
 // ============================================================================
-
-/// Supported CryptoTensors format version
-pub const CRYPTOTENSORS_VERSION: &str = "1";
-
+/// CryptoTensors V1 format version (Monolithic Encryption)
+pub const CRYPTOTENSORS_VERSION_V1: &str = "1";
+/// CryptoTensors V2 format version (Chunked Encryption)
+pub const CRYPTOTENSORS_VERSION_V2: &str = "2";
 /// Minimum number of tensors required to use rayon parallel iteration for
 /// context preparation (Base64 decode, DEK unwrap, Key Schedule).
 /// Below this threshold, serial iteration avoids thread scheduling overhead.
 const PARALLEL_CONTEXT_THRESHOLD: usize = 16;
+
+/// Default chunk size for tensor fractional encryption = 2MB
+pub const DEFAULT_CHUNK_SIZE: usize = 2 * 1024 * 1024;
 
 // ============================================================================
 // Error Types - Organized by category using thiserror
@@ -229,6 +232,11 @@ mod cryptor_serde {
     }
 }
 
+/// Check if OnceCell<String> is empty
+fn is_empty_cell(cell: &OnceCell<String>) -> bool {
+    cell.get().is_none()
+}
+
 /// Configuration for serializing tensors with encryption
 ///
 /// Key loading: (1) Direct keys (`enc_key`/`sign_key`) — use as-is, ignore kid/jku.
@@ -254,6 +262,12 @@ pub struct SerializeCryptoConfig {
 
     /// Tensors to encrypt (None = all)
     pub tensor_filter: Option<Vec<String>>,
+
+    /// Size in bytes for chunked encryption. If None, uses DEFAULT_CHUNK_SIZE.
+    pub chunk_size: Option<usize>,
+
+    /// Format version to serialize to ("1" or "2"). Defaults to "2".
+    pub version: Option<String>,
 }
 
 impl SerializeCryptoConfig {
@@ -307,6 +321,11 @@ impl SerializeCryptoConfig {
     /// Set tensor filter
     pub fn tensor_filter(mut self, filter: Vec<String>) -> Self {
         self.tensor_filter = Some(filter);
+        self
+    }
+    /// Set chunk size
+    pub fn chunk_size(mut self, size: usize) -> Self {
+        self.chunk_size = Some(size);
         self
     }
 }
@@ -365,12 +384,18 @@ pub struct SingleCryptor {
     /// Authentication tag for key encryption encoded in base64
     #[serde(with = "cryptor_serde")]
     key_tag: OnceCell<String>,
-    /// Initialization vector for data encryption encoded in base64
-    #[serde(with = "cryptor_serde")]
+    /// Initialization vector for data encryption encoded in base64 (v1 format)
+    #[serde(default, skip_serializing_if = "is_empty_cell", with = "cryptor_serde")]
     iv: OnceCell<String>,
-    /// Authentication tag for data encryption encoded in base64
-    #[serde(with = "cryptor_serde")]
+    /// Authentication tag for data encryption encoded in base64 (v1 format)
+    #[serde(default, skip_serializing_if = "is_empty_cell", with = "cryptor_serde")]
     tag: OnceCell<String>,
+    /// Base IV for chunked encryption data IV derivation encoded in base64 (v2 format)
+    #[serde(default, skip_serializing_if = "is_empty_cell", with = "cryptor_serde")]
+    base_iv: OnceCell<String>,
+    /// Concatenated authentication tags for chunked data encryption encoded in base64 (v2 format)
+    #[serde(default, skip_serializing_if = "is_empty_cell", with = "cryptor_serde")]
+    tags: OnceCell<String>,
     /// Buffer for decrypted data (Arc for zero-copy sharing with Python)
     #[serde(skip)]
     buffer: OnceCell<Arc<Vec<u8>>>,
@@ -383,10 +408,14 @@ pub struct SingleCryptor {
 pub(crate) struct CryptoContext {
     /// Prepared key context for data decryption
     pub(crate) data_key_ctx: PreparedKeyContext,
-    /// Initialization vector bytes
-    pub(crate) iv: Vec<u8>,
-    /// Authentication tag bytes
-    pub(crate) tag: Vec<u8>,
+    /// Initialization vector bytes (v1)
+    pub(crate) iv: Option<Vec<u8>>,
+    /// Authentication tag bytes (v1)
+    pub(crate) tag: Option<Vec<u8>>,
+    /// Base IV bytes for chunk derivation (v2)
+    pub(crate) base_iv: Option<Vec<u8>>,
+    /// Concatenated tag bytes (v2)
+    pub(crate) tags: Option<Vec<u8>>,
     /// Plaintext DEK — stored in a Zeroizing wrapper so the buffer is wiped on drop
     pub(crate) data_key: Zeroizing<Vec<u8>>,
 }
@@ -395,8 +424,10 @@ impl fmt::Debug for CryptoContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CryptoContext")
             .field("data_key_ctx", &self.data_key_ctx)
-            .field("iv", &self.iv)
-            .field("tag", &self.tag)
+            .field("iv", &self.iv.is_some())
+            .field("tag", &self.tag.is_some())
+            .field("base_iv", &self.base_iv.is_some())
+            .field("tags_len", &self.tags.as_ref().map(|t| t.len()))
             .field("data_key", &"[REDACTED]")
             .finish()
     }
@@ -426,6 +457,8 @@ impl SingleCryptor {
             key_tag: OnceCell::new(),
             iv: OnceCell::new(),
             tag: OnceCell::new(),
+            base_iv: OnceCell::new(),
+            tags: OnceCell::new(),
             buffer: OnceCell::new(),
             ctx: OnceCell::new(),
         })
@@ -502,20 +535,32 @@ impl SingleCryptor {
             return Ok(());
         }
 
-        let iv = BASE64
-            .decode(
-                self.iv
-                    .get()
-                    .ok_or_else(|| CryptoTensorsError::KeyUnwrap("iv is empty".to_string()))?,
-            )
+        let iv = self
+            .iv
+            .get()
+            .map(|s| BASE64.decode(s))
+            .transpose()
             .map_err(|e| CryptoTensorsError::KeyUnwrap(e.to_string()))?;
 
-        let tag = BASE64
-            .decode(
-                self.tag
-                    .get()
-                    .ok_or_else(|| CryptoTensorsError::KeyUnwrap("tag is empty".to_string()))?,
-            )
+        let tag = self
+            .tag
+            .get()
+            .map(|s| BASE64.decode(s))
+            .transpose()
+            .map_err(|e| CryptoTensorsError::KeyUnwrap(e.to_string()))?;
+
+        let base_iv = self
+            .base_iv
+            .get()
+            .map(|s| BASE64.decode(s))
+            .transpose()
+            .map_err(|e| CryptoTensorsError::KeyUnwrap(e.to_string()))?;
+
+        let tags = self
+            .tags
+            .get()
+            .map(|s| BASE64.decode(s))
+            .transpose()
             .map_err(|e| CryptoTensorsError::KeyUnwrap(e.to_string()))?;
 
         let mut data_key = Zeroizing::new(
@@ -551,6 +596,8 @@ impl SingleCryptor {
                 data_key_ctx,
                 iv,
                 tag,
+                base_iv,
+                tags,
                 data_key,
             }))
             .map_err(|_| {
@@ -580,6 +627,7 @@ impl SingleCryptor {
         file: &std::fs::File,
         file_offset: u64,
         len: usize,
+        chunk_size: Option<usize>,
     ) -> Result<&[u8], CryptoTensorsError> {
         self.buffer
             .get_or_try_init(|| {
@@ -587,7 +635,82 @@ impl SingleCryptor {
                     CryptoTensorsError::Decryption("Context not prepared".to_string())
                 })?;
 
-                // Atomic positioned read: pread (Unix) / seek_read (Windows)
+                let get_strategy = || -> String {
+                    std::env::var("CRYPTOTENSORS_PREAD_STRATEGY")
+                        .unwrap_or_else(|_| "B".to_string())
+                };
+
+                // Pipeline Pread Strategy B (Only applicable for V2 chunked encryption on Unix)
+                #[cfg(unix)]
+                {
+                    if let (Some(c_size), "B") = (chunk_size, get_strategy().as_str()) {
+                        let mut buffer = vec![0u8; len];
+                        let tags = ctx_arc.tags.as_ref().ok_or_else(|| {
+                            CryptoTensorsError::Decryption(
+                                "Missing tags for chunked decryption".to_string(),
+                            )
+                        })?;
+                        let base_iv = ctx_arc.base_iv.as_ref().ok_or_else(|| {
+                            CryptoTensorsError::Decryption(
+                                "Missing base_iv for chunked decryption".to_string(),
+                            )
+                        })?;
+                        let tag_len = ctx_arc.data_key_ctx.algo.tag_len();
+
+                        if buffer.is_empty() {
+                            if tags.len() < tag_len {
+                                return Err(CryptoTensorsError::Decryption(
+                                    "Missing tag for empty tensor".to_string(),
+                                ));
+                            }
+                            crate::encryption::decrypt_data(
+                                &mut [],
+                                &ctx_arc.data_key_ctx,
+                                base_iv,
+                                &tags[0..tag_len],
+                            )?;
+                        } else {
+                            use std::os::unix::fs::FileExt;
+
+                            buffer.par_chunks_mut(c_size).enumerate().try_for_each(
+                                |(i, chunk)| {
+                                    let expected_offset = i * tag_len;
+                                    if expected_offset + tag_len > tags.len() {
+                                        return Err(CryptoTensorsError::Decryption(format!(
+                                            "Missing tag for chunk {}",
+                                            i
+                                        )));
+                                    }
+                                    let tag = &tags[expected_offset..expected_offset + tag_len];
+
+                                    // 1. Derive IV (pure CPU, hidden latency before IO blocking)
+                                    let iv = crate::encryption::derive_chunk_iv(base_iv, i)?;
+
+                                    // 2. Parallel pread for this specific chunk
+                                    let chunk_file_offset = file_offset + (i * c_size) as u64;
+                                    file.read_exact_at(chunk, chunk_file_offset).map_err(|e| {
+                                        CryptoTensorsError::Decryption(format!(
+                                            "pread failed: {}",
+                                            e
+                                        ))
+                                    })?;
+
+                                    // 3. In-place decryption
+                                    crate::encryption::decrypt_data(
+                                        chunk,
+                                        &ctx_arc.data_key_ctx,
+                                        &iv,
+                                        tag,
+                                    )
+                                },
+                            )?;
+                        }
+
+                        return Ok(Arc::new(buffer));
+                    }
+                }
+
+                // Strategy A (Monolithic Pread) or Fallback for V1/Non-Unix
                 let mut buffer = vec![0u8; len];
                 #[cfg(unix)]
                 {
@@ -628,12 +751,7 @@ impl SingleCryptor {
                     })?;
                 }
 
-                decrypt_data(
-                    &mut buffer,
-                    &ctx_arc.data_key_ctx,
-                    &ctx_arc.iv,
-                    &ctx_arc.tag,
-                )?;
+                self.perform_decryption(&mut buffer, &ctx_arc, chunk_size)?;
 
                 Ok(Arc::new(buffer))
             })
@@ -644,7 +762,7 @@ impl SingleCryptor {
     ///
     /// This copies the data from the provided slice and decrypts in-place.
     /// Used by both the Rust crate API and Python bindings (when data is already in memory).
-    fn decrypt(&self, data: &[u8]) -> Result<&[u8], CryptoTensorsError> {
+    fn decrypt(&self, data: &[u8], chunk_size: Option<usize>) -> Result<&[u8], CryptoTensorsError> {
         self.buffer
             .get_or_try_init(|| {
                 let ctx_arc = self.ctx.get().ok_or_else(|| {
@@ -652,16 +770,71 @@ impl SingleCryptor {
                 })?;
 
                 let mut buffer = data.to_vec();
-                decrypt_data(
-                    &mut buffer,
-                    &ctx_arc.data_key_ctx,
-                    &ctx_arc.iv,
-                    &ctx_arc.tag,
-                )?;
+                self.perform_decryption(&mut buffer, &ctx_arc, chunk_size)?;
 
                 Ok(Arc::new(buffer))
             })
             .map(|arc_ref| arc_ref.as_slice())
+    }
+
+    /// Perform the actual decryption on an in-memory buffer (V1 or V2 chunked)
+    fn perform_decryption(
+        &self,
+        buffer: &mut [u8],
+        ctx_arc: &CryptoContext,
+        chunk_size: Option<usize>,
+    ) -> Result<(), CryptoTensorsError> {
+        if let Some(c_size) = chunk_size {
+            // V2 chunked decryption
+            let base_iv = ctx_arc.base_iv.as_ref().ok_or_else(|| {
+                CryptoTensorsError::Decryption("Missing base_iv for chunked decryption".to_string())
+            })?;
+            let tags = ctx_arc.tags.as_ref().ok_or_else(|| {
+                CryptoTensorsError::Decryption("Missing tags for chunked decryption".to_string())
+            })?;
+
+            let tag_len = ctx_arc.data_key_ctx.algo.tag_len();
+
+            if buffer.is_empty() {
+                if tags.len() < tag_len {
+                    return Err(CryptoTensorsError::Decryption(
+                        "Missing tag for empty tensor".to_string(),
+                    ));
+                }
+                crate::encryption::decrypt_data(
+                    &mut [],
+                    &ctx_arc.data_key_ctx,
+                    base_iv,
+                    &tags[0..tag_len],
+                )?;
+            } else {
+                buffer
+                    .par_chunks_mut(c_size)
+                    .enumerate()
+                    .try_for_each(|(i, chunk)| {
+                        let expected_offset = i * tag_len;
+                        if expected_offset + tag_len > tags.len() {
+                            return Err(CryptoTensorsError::Decryption(format!(
+                                "Missing tag for chunk {}",
+                                i
+                            )));
+                        }
+                        let tag = &tags[expected_offset..expected_offset + tag_len];
+                        let iv = crate::encryption::derive_chunk_iv(base_iv, i)?;
+                        crate::encryption::decrypt_data(chunk, &ctx_arc.data_key_ctx, &iv, tag)
+                    })?;
+            }
+        } else {
+            // V1
+            let iv = ctx_arc.iv.as_ref().ok_or_else(|| {
+                CryptoTensorsError::Decryption("Missing iv for v1 decryption".to_string())
+            })?;
+            let tag = ctx_arc.tag.as_ref().ok_or_else(|| {
+                CryptoTensorsError::Decryption("Missing tag for v1 decryption".to_string())
+            })?;
+            crate::encryption::decrypt_data(buffer, &ctx_arc.data_key_ctx, iv, tag)?;
+        }
+        Ok(())
     }
 
     /// Encrypt data using the master key
@@ -684,18 +857,72 @@ impl SingleCryptor {
         &self,
         data: &[u8],
         master_key_ctx: &PreparedKeyContext,
+        chunk_size: Option<usize>,
     ) -> Result<(), CryptoTensorsError> {
         let data_key = Zeroizing::new(self.random_key()?);
         let data_key_ctx = prepare_key_context(&data_key, &self.enc_algo)?;
 
         let mut buffer = data.to_vec();
-        let (iv, tag) = encrypt_data(&mut buffer, &data_key_ctx)?;
-        self.iv
-            .set(BASE64.encode(&iv))
-            .map_err(|_| CryptoTensorsError::Encryption("Failed to set iv".to_string()))?;
-        self.tag
-            .set(BASE64.encode(&tag))
-            .map_err(|_| CryptoTensorsError::Encryption("Failed to set tag".to_string()))?;
+
+        let mut out_iv = None;
+        let mut out_tag = None;
+        let mut out_base_iv = None;
+        let mut out_tags = None;
+
+        if let Some(c_size) = chunk_size {
+            let aead_algo = data_key_ctx.algo.get_aead_algo();
+            let mut base_iv = vec![0u8; aead_algo.nonce_len()];
+            let rng = rand::SystemRandom::new();
+            rng.fill(&mut base_iv)
+                .map_err(|e| CryptoTensorsError::RandomGeneration(e.to_string()))?;
+
+            let chunk_count = (buffer.len() + c_size - 1) / c_size;
+            let mut all_tags =
+                vec![0u8; std::cmp::max(1, chunk_count) * data_key_ctx.algo.tag_len()];
+
+            if buffer.is_empty() {
+                let tag =
+                    crate::encryption::encrypt_data_with_iv(&mut [], &data_key_ctx, &base_iv)?;
+                all_tags[0..tag.len()].copy_from_slice(&tag);
+            } else {
+                let tags_res: Result<Vec<Vec<u8>>, CryptoTensorsError> = buffer
+                    .par_chunks_mut(c_size)
+                    .enumerate()
+                    .map(|(i, chunk)| {
+                        let chunk_iv = crate::encryption::derive_chunk_iv(&base_iv, i)?;
+                        crate::encryption::encrypt_data_with_iv(chunk, &data_key_ctx, &chunk_iv)
+                    })
+                    .collect();
+
+                let tags_vec = tags_res?;
+                all_tags.clear();
+                for tag in tags_vec {
+                    all_tags.extend_from_slice(&tag);
+                }
+            }
+
+            self.base_iv
+                .set(BASE64.encode(&base_iv))
+                .map_err(|_| CryptoTensorsError::Encryption("Failed to set base_iv".to_string()))?;
+            self.tags
+                .set(BASE64.encode(&all_tags))
+                .map_err(|_| CryptoTensorsError::Encryption("Failed to set tags".to_string()))?;
+
+            out_base_iv = Some(base_iv);
+            out_tags = Some(all_tags);
+        } else {
+            let (iv, tag) = encrypt_data(&mut buffer, &data_key_ctx)?;
+            self.iv
+                .set(BASE64.encode(&iv))
+                .map_err(|_| CryptoTensorsError::Encryption("Failed to set iv".to_string()))?;
+            self.tag
+                .set(BASE64.encode(&tag))
+                .map_err(|_| CryptoTensorsError::Encryption("Failed to set tag".to_string()))?;
+
+            out_iv = Some(iv);
+            out_tag = Some(tag);
+        }
+
         self.wrap_key(&data_key, master_key_ctx)?;
         self.buffer
             .set(Arc::new(buffer))
@@ -704,8 +931,10 @@ impl SingleCryptor {
         self.ctx
             .set(Arc::new(CryptoContext {
                 data_key_ctx,
-                iv,
-                tag,
+                iv: out_iv,
+                tag: out_tag,
+                base_iv: out_base_iv,
+                tags: out_tags,
                 data_key,
             }))
             .map_err(|_| {
@@ -781,8 +1010,10 @@ impl SingleCryptor {
             wrapped_key: OnceCell::new(),
             key_iv: OnceCell::new(),
             key_tag: OnceCell::new(),
-            iv: self.iv.clone(),     // Preserve data encryption IV (if set)
-            tag: self.tag.clone(),   // Preserve data encryption tag (if set)
+            iv: self.iv.clone(), // Preserve data encryption IV (if set, v1 format)
+            tag: self.tag.clone(), // Preserve data encryption tag (if set, v1 format)
+            base_iv: self.base_iv.clone(), // Preserve v2 base_iv
+            tags: self.tags.clone(), // Preserve v2 tags
             buffer: OnceCell::new(), // Clear buffer (master_key changed)
             ctx: self.ctx.clone(), // Preserve prepared context, it's valid regardless of master key
         };
@@ -816,6 +1047,8 @@ impl Clone for SingleCryptor {
             key_tag: self.key_tag.clone(),
             iv: self.iv.clone(),
             tag: self.tag.clone(),
+            base_iv: self.base_iv.clone(),
+            tags: self.tags.clone(),
             buffer: self.buffer.clone(),
             ctx: self.ctx.clone(),
         }
@@ -925,6 +1158,8 @@ pub struct CryptoTensors {
     policy: AccessPolicy,
     /// CryptoTensors version
     version: String,
+    /// Chunk size for chunked encryption data IV derivation (v2 format)
+    chunk_size: Option<usize>,
 }
 
 impl CryptoTensors {
@@ -996,13 +1231,25 @@ impl CryptoTensors {
         // Create signer
         let signer = HeaderSigner::new(&sign_key)?;
 
+        let version = config
+            .version
+            .clone()
+            .unwrap_or_else(|| CRYPTOTENSORS_VERSION_V2.to_string());
+
+        let chunk_size = if version == CRYPTOTENSORS_VERSION_V1 {
+            None
+        } else {
+            Some(config.chunk_size.unwrap_or(DEFAULT_CHUNK_SIZE))
+        };
+
         Ok(Some(Self {
             cryptors,
             enc_key,
             sign_key,
             signer,
             policy: config.policy.clone().unwrap_or_default(),
-            version: CRYPTOTENSORS_VERSION.to_string(),
+            version,
+            chunk_size,
         }))
     }
 
@@ -1038,11 +1285,17 @@ impl CryptoTensors {
         new_metadata.remove("__policy__");
 
         // Add key material information
-        let key_material = serde_json::json!({
+        let mut key_material = serde_json::json!({
             "version": self.version,
             "enc": self.enc_key,
             "sign": self.sign_key
         });
+        if let Some(cs) = self.chunk_size {
+            key_material
+                .as_object_mut()
+                .unwrap()
+                .insert("chunk_size".to_string(), serde_json::json!(cs));
+        }
         let key_material_json = serde_json::to_string(&key_material)
             .map_err(|e| CryptoTensorsError::Encryption(e.to_string()))?;
         new_metadata.insert("__crypto_keys__".to_string(), key_material_json);
@@ -1239,9 +1492,13 @@ impl CryptoTensors {
             .get("version")
             .and_then(|v| v.as_str())
             .ok_or(CryptoTensorsError::MissingVersion)?;
-        if version != CRYPTOTENSORS_VERSION {
+        if version != CRYPTOTENSORS_VERSION_V1 && version != CRYPTOTENSORS_VERSION_V2 {
             return Err(CryptoTensorsError::UnsupportedVersion(version.to_string()));
         }
+        let chunk_size = key_materials
+            .get("chunk_size")
+            .and_then(|v| v.as_u64())
+            .map(|v| v as usize);
         let mut enc_key = KeyMaterial::from_header(&key_materials["enc"])?;
         let mut sign_key = KeyMaterial::from_header(&key_materials["sign"])?;
 
@@ -1343,6 +1600,7 @@ impl CryptoTensors {
             sign_key,
             policy,
             version: version.to_string(),
+            chunk_size,
         }))
     }
 
@@ -1365,7 +1623,7 @@ impl CryptoTensors {
     ) -> Result<(), CryptoTensorsError> {
         match self.get(tensor_name) {
             Some(cryptor) => {
-                cryptor.decrypt_from_file(file, file_offset, len)?;
+                cryptor.decrypt_from_file(file, file_offset, len, self.chunk_size)?;
                 Ok(())
             }
             None => Ok(()),
@@ -1381,7 +1639,12 @@ impl CryptoTensors {
         data: &'a [u8],
     ) -> Result<&'a [u8], CryptoTensorsError> {
         match self.get(tensor_name) {
-            Some(cryptor) => cryptor.decrypt(data),
+            Some(cryptor) => {
+                cryptor.decrypt(data, self.chunk_size)?;
+                cryptor.buffer.get().map(|b| b.as_slice()).ok_or_else(|| {
+                    CryptoTensorsError::Decryption("Decrypted buffer not available".to_string())
+                })
+            }
             None => Ok(data),
         }
     }
@@ -1405,7 +1668,7 @@ impl CryptoTensors {
 
         for (name, cryptor) in &self.cryptors {
             if let Some(data) = get_data(name) {
-                cryptor.encrypt(&data, &master_key_ctx)?;
+                cryptor.encrypt(&data, &master_key_ctx, self.chunk_size)?;
             }
         }
         Ok(())

--- a/safetensors/src/cryptotensors.rs
+++ b/safetensors/src/cryptotensors.rs
@@ -635,6 +635,7 @@ impl SingleCryptor {
                     CryptoTensorsError::Decryption("Context not prepared".to_string())
                 })?;
 
+                #[allow(unused_variables)]
                 let get_strategy = || -> String {
                     std::env::var("CRYPTOTENSORS_PREAD_STRATEGY")
                         .unwrap_or_else(|_| "B".to_string())

--- a/safetensors/src/cryptotensors.rs
+++ b/safetensors/src/cryptotensors.rs
@@ -750,8 +750,7 @@ impl SingleCryptor {
                         CryptoTensorsError::Decryption(format!("read failed: {}", e))
                     })?;
                 }
-
-                self.perform_decryption(&mut buffer, &ctx_arc, chunk_size)?;
+                self.perform_decryption(&mut buffer, ctx_arc, chunk_size)?;
 
                 Ok(Arc::new(buffer))
             })
@@ -770,7 +769,7 @@ impl SingleCryptor {
                 })?;
 
                 let mut buffer = data.to_vec();
-                self.perform_decryption(&mut buffer, &ctx_arc, chunk_size)?;
+                self.perform_decryption(&mut buffer, ctx_arc, chunk_size)?;
 
                 Ok(Arc::new(buffer))
             })
@@ -875,8 +874,7 @@ impl SingleCryptor {
             let rng = rand::SystemRandom::new();
             rng.fill(&mut base_iv)
                 .map_err(|e| CryptoTensorsError::RandomGeneration(e.to_string()))?;
-
-            let chunk_count = (buffer.len() + c_size - 1) / c_size;
+            let chunk_count = buffer.len().div_ceil(c_size);
             let mut all_tags =
                 vec![0u8; std::cmp::max(1, chunk_count) * data_key_ctx.algo.tag_len()];
 

--- a/safetensors/src/encryption.rs
+++ b/safetensors/src/encryption.rs
@@ -188,6 +188,44 @@ pub fn encrypt_data(
     Ok((nonce_bytes, tag.as_ref().to_vec()))
 }
 
+/// Encrypt data using a prepared key context and a specific IV
+///
+/// # Arguments
+///
+/// * `in_out` - The buffer containing the data to encrypt.
+/// * `ctx` - The prepared key context
+/// * `iv` - The IV to use for encryption
+pub fn encrypt_data_with_iv(
+    in_out: &mut [u8],
+    ctx: &PreparedKeyContext,
+    iv: &[u8],
+) -> Result<Vec<u8>, CryptoTensorsError> {
+    if in_out.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let aead_algo = ctx.algo.get_aead_algo();
+    if iv.len() != aead_algo.nonce_len() {
+        return Err(CryptoTensorsError::InvalidIvLength {
+            expected: aead_algo.nonce_len(),
+            actual: iv.len(),
+        });
+    }
+
+    let mut nonce_bytes = vec![0u8; aead_algo.nonce_len()];
+    nonce_bytes.copy_from_slice(iv);
+    // Length is verified to be exactly nonce_len()
+    let nonce = aead::Nonce::assume_unique_for_key(nonce_bytes.try_into().unwrap());
+
+    // Encrypt the data in place
+    let tag = ctx
+        .key
+        .seal_in_place_separate_tag(nonce, aead::Aad::empty(), in_out)
+        .map_err(|e| CryptoTensorsError::Encryption(e.to_string()))?;
+
+    Ok(tag.as_ref().to_vec())
+}
+
 /// Decrypt data using a prepared key context
 ///
 /// # Arguments
@@ -245,4 +283,74 @@ pub fn decrypt_data(
         .map_err(|e| CryptoTensorsError::Decryption(e.to_string()))?;
 
     Ok(())
+}
+
+/// Derives the IV for a specific chunk using a base IV and the chunk index.
+///
+/// Complies with NIST SP 800-38D deterministic IV construction:
+/// IV = base_iv[0..8] || (u32_from_be(base_iv[8..12]) + chunk_index).to_be_bytes()
+/// Supported algorithms (AES-GCM, ChaCha20-Poly1305) use 12-byte nonces.
+///
+/// # Arguments
+///
+/// * `base_iv` - The 12-byte base IV generated for the tensor
+/// * `chunk_index` - The zero-based index of the chunk
+pub fn derive_chunk_iv(base_iv: &[u8], chunk_index: usize) -> Result<Vec<u8>, CryptoTensorsError> {
+    if base_iv.len() < 12 {
+        return Err(CryptoTensorsError::InvalidIvLength {
+            expected: 12,
+            actual: base_iv.len(),
+        });
+    }
+
+    let mut iv = base_iv[0..12].to_vec();
+    let mut counter_bytes = [0u8; 4];
+    counter_bytes.copy_from_slice(&iv[8..12]);
+    let counter = u32::from_be_bytes(counter_bytes);
+
+    let new_counter = counter.wrapping_add(chunk_index as u32);
+    iv[8..12].copy_from_slice(&new_counter.to_be_bytes());
+
+    Ok(iv)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_derive_chunk_iv() {
+        let base_iv = vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0];
+
+        // Chunk 0
+        let iv_0 = derive_chunk_iv(&base_iv, 0).unwrap();
+        assert_eq!(iv_0, vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0]);
+
+        // Chunk 1
+        let iv_1 = derive_chunk_iv(&base_iv, 1).unwrap();
+        assert_eq!(iv_1, vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 1]);
+
+        // Chunk 256 (wraps second byte)
+        let iv_256 = derive_chunk_iv(&base_iv, 256).unwrap();
+        assert_eq!(iv_256, vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 1, 0]);
+
+        // Base IV with non-zero counter
+        let base_iv_non_zero = vec![0, 1, 2, 3, 4, 5, 6, 7, 255, 255, 255, 255];
+        let iv_wrap = derive_chunk_iv(&base_iv_non_zero, 1).unwrap();
+        assert_eq!(iv_wrap, vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0]); // wrapping_add overflow
+    }
+
+    #[test]
+    fn test_derive_chunk_iv_invalid_length() {
+        let short_iv = vec![0; 11];
+        let res = derive_chunk_iv(&short_iv, 0);
+        assert!(res.is_err());
+        match res.unwrap_err() {
+            CryptoTensorsError::InvalidIvLength { expected, actual } => {
+                assert_eq!(expected, 12);
+                assert_eq!(actual, 11);
+            }
+            _ => panic!("Expected InvalidIvLength error"),
+        }
+    }
 }

--- a/safetensors/src/encryption.rs
+++ b/safetensors/src/encryption.rs
@@ -200,10 +200,6 @@ pub fn encrypt_data_with_iv(
     ctx: &PreparedKeyContext,
     iv: &[u8],
 ) -> Result<Vec<u8>, CryptoTensorsError> {
-    if in_out.is_empty() {
-        return Ok(Vec::new());
-    }
-
     let aead_algo = ctx.algo.get_aead_algo();
     if iv.len() != aead_algo.nonce_len() {
         return Err(CryptoTensorsError::InvalidIvLength {
@@ -308,7 +304,11 @@ pub fn derive_chunk_iv(base_iv: &[u8], chunk_index: usize) -> Result<Vec<u8>, Cr
     counter_bytes.copy_from_slice(&iv[8..12]);
     let counter = u32::from_be_bytes(counter_bytes);
 
-    let new_counter = counter.wrapping_add(chunk_index as u32);
+    let chunk_idx_u32 = u32::try_from(chunk_index)
+        .map_err(|_| CryptoTensorsError::Encryption("Chunk index exceeds u32 max".to_string()))?;
+    let new_counter = counter.checked_add(chunk_idx_u32).ok_or_else(|| {
+        CryptoTensorsError::Encryption("Chunk index overflowed IV counter".to_string())
+    })?;
     iv[8..12].copy_from_slice(&new_counter.to_be_bytes());
 
     Ok(iv)
@@ -336,8 +336,8 @@ mod tests {
 
         // Base IV with non-zero counter
         let base_iv_non_zero = vec![0, 1, 2, 3, 4, 5, 6, 7, 255, 255, 255, 255];
-        let iv_wrap = derive_chunk_iv(&base_iv_non_zero, 1).unwrap();
-        assert_eq!(iv_wrap, vec![0, 1, 2, 3, 4, 5, 6, 7, 0, 0, 0, 0]); // wrapping_add overflow
+        let res = derive_chunk_iv(&base_iv_non_zero, 1);
+        assert!(res.is_err()); // checked_add overflow should return an error
     }
 
     #[test]


### PR DESCRIPTION
# What does this PR do?

This pull request introduces support for CryptoTensors format version 2 (v2), which implements chunked encryption for improved performance and parallelism. It updates the format specification, the Rust and Python APIs, and the test suite to handle both v1 (monolithic) and v2 (chunked) encryption modes. The changes also clarify and document the file format, add configurability for chunk size and version, and ensure backward compatibility.

**Format specification and documentation:**
- Added a comprehensive `FORMAT.md` describing the CryptoTensors file format, including both v1 (monolithic) and v2 (chunked) encryption layouts, header structure, and metadata fields.
- Updated `README.md` to clarify the meaning and usage of the `__crypto_keys__` and `__encryption__` fields, and to direct users to the new format specification for details on v1 vs v2.

**Core Rust library enhancements:**
- Introduced support for v2 chunked encryption: added `chunk_size` and `version` fields to `SerializeCryptoConfig`, new fields (`base_iv`, `tags`) to `SingleCryptor`, and logic to handle both v1 and v2 metadata during serialization and decryption. Default chunk size is now 2MB. [[1]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL29-R40) [[2]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR265-R270) [[3]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL368-R398) [[4]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL386-R418) [[5]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR460-R461) [[6]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL505-R563) [[7]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR599-R600)
- Updated version constants, default behaviors, and serialization logic to support both format versions and to skip empty fields as appropriate. [[1]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL29-R40) [[2]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR265-R270) [[3]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR326-R330)

**Python bindings and API:**
- Extended the Python `SerializeCryptoConfig` API to accept `chunk_size` and `version` parameters, defaulting to v2 if unspecified. Updated Rust FFI glue to pass these options through. [[1]](diffhunk://#diff-20e52391364d1a71ee3f76f4d97368b08014ce8686c234a35cbd81a31fe13877R130-R131) [[2]](diffhunk://#diff-20e52391364d1a71ee3f76f4d97368b08014ce8686c234a35cbd81a31fe13877R145-R146) [[3]](diffhunk://#diff-20e52391364d1a71ee3f76f4d97368b08014ce8686c234a35cbd81a31fe13877R157-R158) [[4]](diffhunk://#diff-57af18dbd0070e35a14e183a52ece76c980f7c45f3dd3835cfacfcc0669a9884R640-R649)
- Incremented version numbers for both the Rust crate and the Python package to `0.2.3`. [[1]](diffhunk://#diff-dc879c68a9a94201fb1c9a4e4e7bfdd9c084ec3d78fd5b2832ad128a9636ac5bL3-R3) [[2]](diffhunk://#diff-4828eff974e2292d67f267637f1a0d57cb8c599b08b518af3066f98eca15be75L6-R6)

**Testing improvements:**
- Enhanced test utilities and cases to support the new options, including tests for v1 and v2 roundtrips, and explicit configuration of chunk size and version. [[1]](diffhunk://#diff-7cc9ef1e0a63bb28a973631abad29da47e8f0d5ae322975673160b7864acdf48L79-R79) [[2]](diffhunk://#diff-7cc9ef1e0a63bb28a973631abad29da47e8f0d5ae322975673160b7864acdf48R88) [[3]](diffhunk://#diff-7cc9ef1e0a63bb28a973631abad29da47e8f0d5ae322975673160b7864acdf48R101) [[4]](diffhunk://#diff-da8d32ab2d5178ec169ebf61ca0ebab8a9decffa5801efc049b73a2cc648b261R12-R20) [[5]](diffhunk://#diff-0e35002604b6f6bf5ddfa21221f42f356d222f185a4bc9ca54e903ca053d90e7R44-R70)

**Summary of most important changes:**

**1. Format and Metadata Enhancements**
- Added `FORMAT.md` with detailed v1/v2 specification, and updated `README.md` to clarify metadata fields and versioning. [[1]](diffhunk://#diff-3869e7afb262d3246d5fb06d07a83b365705c8e00293ca6e0db8c2e8c888fb0eR1-R108) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R155)

**2. Rust Core Library: v2 Chunked Encryption**
- Introduced `chunk_size` and `version` fields to `SerializeCryptoConfig`, and added chunked encryption fields (`base_iv`, `tags`) to `SingleCryptor` for v2 support. [[1]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL29-R40) [[2]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR265-R270) [[3]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL368-R398) [[4]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL386-R418) [[5]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR460-R461) [[6]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL505-R563) [[7]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR599-R600)
- Updated serialization/deserialization logic and version constants to support both v1 and v2. [[1]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eL29-R40) [[2]](diffhunk://#diff-1ed1eb091a7de0f7d8ce2d60186d89a2ee05a5a4f4d276009f46f1e6997b3a2eR326-R330)

**3. Python Bindings and API**
- Extended Python API and FFI to allow configuring `chunk_size` and `version` for encryption, defaulting to v2. [[1]](diffhunk://#diff-20e52391364d1a71ee3f76f4d97368b08014ce8686c234a35cbd81a31fe13877R130-R131) [[2]](diffhunk://#diff-20e52391364d1a71ee3f76f4d97368b08014ce8686c234a35cbd81a31fe13877R145-R146) [[3]](diffhunk://#diff-20e52391364d1a71ee3f76f4d97368b08014ce8686c234a35cbd81a31fe13877R157-R158) [[4]](diffhunk://#diff-57af18dbd0070e35a14e183a52ece76c980f7c45f3dd3835cfacfcc0669a9884R640-R649)

**4. Testing and Utilities**
- Updated test helpers and added explicit tests for v1/v2 roundtrips and chunk size configuration. [[1]](diffhunk://#diff-7cc9ef1e0a63bb28a973631abad29da47e8f0d5ae322975673160b7864acdf48L79-R79) [[2]](diffhunk://#diff-7cc9ef1e0a63bb28a973631abad29da47e8f0d5ae322975673160b7864acdf48R88) [[3]](diffhunk://#diff-7cc9ef1e0a63bb28a973631abad29da47e8f0d5ae322975673160b7864acdf48R101) [[4]](diffhunk://#diff-da8d32ab2d5178ec169ebf61ca0ebab8a9decffa5801efc049b73a2cc648b261R12-R20) [[5]](diffhunk://#diff-0e35002604b6f6bf5ddfa21221f42f356d222f185a4bc9ca54e903ca053d90e7R44-R70)

**5. Version Bumps**
- Bumped Rust crate and Python package versions to `0.2.3`. [[1]](diffhunk://#diff-dc879c68a9a94201fb1c9a4e4e7bfdd9c084ec3d78fd5b2832ad128a9636ac5bL3-R3) [[2]](diffhunk://#diff-4828eff974e2292d67f267637f1a0d57cb8c599b08b518af3066f98eca15be75L6-R6)